### PR TITLE
Feature/exclude domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.79.0-stable as build
+FROM clux/muslrust:1.85.0-stable as build
 
 # Get source
 COPY . .

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn is_link_annotation(annotation: &Dictionary) -> bool {
         .get(b"Subtype")
         .ok()
         .and_then(|subtype| subtype.as_name().ok())
-        .map_or(false, |subtype| subtype == b"Link")
+        .is_some_and(|subtype| subtype == b"Link")
 }
 
 // Extract the destination URI from a link annotation

--- a/waybackmachine-client/src/archivableurl.rs
+++ b/waybackmachine-client/src/archivableurl.rs
@@ -14,6 +14,19 @@ const EXCLUDED_DOMAINS: &[&str] = &[
     "diw.de",
     "youtube.com",
     "plato.stanford.edu",
+    "muse.jhu.edu",
+    "read.dukeupress.edu",
+    "academic.oup.com",
+    "onlinelibrary.wiley.com",
+    "genius.com",
+    "taylorfrancis.com",
+    "tandfonline.com",
+    "iwaponline.com",
+    "link.springer.com",
+    "journals.sagepub.com",
+    "journals.openedition.org",
+    "sciencedirect.com",
+    "annualreviews.org",
 ];
 
 impl ArchivableUrl {


### PR DESCRIPTION
Add to list of domains that block wayback requests so that `archive-pdf-urls` fails less often in OBP `book-production` workflow.